### PR TITLE
Example nais.yml.

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -23,6 +23,8 @@ spec:
     paths:
       - kvPath: "serviceuser/data/dev/srvmeldekortservice"
         mountPath: /var/run/secrets/nais.io/srvmeldekortservice
+      - kvPath: kv/preprod/fss/meldekortservice/q1
+        mountPath: /var/run/secrets/nais.io/vault
   replicas:
     min: 2
     max: 4


### PR DESCRIPTION
Need to parameterize kvPath dependent on cluster and namespace.
The mountpath is because NAV java baseimages reads from this path:

See https://github.com/navikt/baseimages/blob/0200bc4d972ca0ff1f9fd64ef19e3fa92cb2b7ec/common/init-scripts/import-env-files.sh#L5