### PR TITLE
Ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,18 +176,15 @@ workflows:
           filters:
             branches:
               only: master
-      - bekreft-deploy-til-p:
+      - bekreft-deploy-til-prod:
           type: approval
           requires:
             - build
             - bygg_og_push
             - manuell-deploy-til-q1
             - manuell-deploy-til-q0
-          filters:
-            branches:
-              ignore: master
-      - deploy-til-p:
-          name: manuell-deploy-til-p
+      - deploy-til-prod:
+          name: manuell-deploy-til-prod
           requires:
-            - bekreft-deploy-til-p
+            - bekreft-deploy-til-prod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,3 +156,23 @@ workflows:
           filters:
             branches:
               only: master
+      - bekreft-deploy-til-q0:
+          type: approval
+          requires:
+            - build
+            - bygg_og_push
+          filters:
+            branches:
+              ignore: master
+      - deploy-til-q0:
+          name: manuell-deploy-til-q0
+          requires:
+            - bekreft-deploy-til-q0
+      - deploy-til-q1:
+          name: automatisk-deploy-til-q0
+          requires:
+            - build
+            - bygg_og_push
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ workflows:
           name: manuell-deploy-til-q0
           requires:
             - bekreft-deploy-til-q0
-      - deploy-til-q1:
+      - deploy-til-q0:
           name: automatisk-deploy-til-q0
           requires:
             - build
@@ -176,3 +176,18 @@ workflows:
           filters:
             branches:
               only: master
+      - bekreft-deploy-til-p:
+          type: approval
+          requires:
+            - build
+            - bygg_og_push
+            - manuell-deploy-til-q1
+            - manuell-deploy-til-q0
+          filters:
+            branches:
+              ignore: master
+      - deploy-til-p:
+          name: manuell-deploy-til-p
+          requires:
+            - bekreft-deploy-til-p
+


### PR DESCRIPTION
Setter opp config for å deploye til q0 og prod.

Ved prodsetting har jeg gjort det sånn at versjonen må være deployet til både q1 og q0 før man kan velge å deploye til prod. Master-brancher vil alltid deployes til både q1 og q0 og man vil derfor alltid kunne velge å deploye disse til prod. Feature-brancher må manuelt godkjennes for deploy til både q1 og q0 før den evt deployes til prod. Si ifra om du mener noe her burde endres.