### PR TITLE
La til personId i data som sendes til meldekortkontroll

### DIFF
--- a/src/main/kotlin/no/nav/meldeplikt/meldekortservice/mapper/MeldekortkontrollMapper.kt
+++ b/src/main/kotlin/no/nav/meldeplikt/meldekortservice/mapper/MeldekortkontrollMapper.kt
@@ -13,6 +13,7 @@ class MeldekortkontrollMapper {
     fun mapMeldekortTilMeldekortkontroll(meldekort: Meldekortdetaljer): Meldekortkontroll {
         return Meldekortkontroll(
             meldekortId = meldekort.meldekortId,
+            personId = meldekort.personId,
             kortType = meldekort.kortType.name,
             kortStatus = "SENDT", // TODO: Finn ut hvordan vi forholder oss til denne. Ligger ikke i request.
             meldegruppe = trekkutMeldegruppe(meldekort),

--- a/src/main/kotlin/no/nav/meldeplikt/meldekortservice/model/meldekortdetaljer/kontroll/Meldekortkontroll.kt
+++ b/src/main/kotlin/no/nav/meldeplikt/meldekortservice/model/meldekortdetaljer/kontroll/Meldekortkontroll.kt
@@ -1,10 +1,11 @@
 package no.nav.meldeplikt.meldekortservice.model.meldekortdetaljer.kontroll
 
 /**
- * Denne typen tilsvarer det som brukes i frontend og i meldekort-kontroll
+ * Denne typen er basert på det som brukes i frontend og i meldekort-kontroll
  */
 data class Meldekortkontroll constructor(
     var meldekortId: Long = 0,
+    var personId: Long = 0,
     var kortType: String,
     var kortStatus: String?,
     var meldegruppe: String,

--- a/src/test/kotlin/no/nav/meldeplikt/meldekortservice/mapper/MeldekortkontrollMapperTest.kt
+++ b/src/test/kotlin/no/nav/meldeplikt/meldekortservice/mapper/MeldekortkontrollMapperTest.kt
@@ -32,6 +32,7 @@ class MeldekortkontrollMapperTest {
         assert(meldekortkontroll.meldeperiode.kortKanSendesFra == LocalDate.parse("2020-02-01", DateTimeFormatter.ISO_DATE))
         assert(meldekortkontroll.meldeperiode.periodeKode == meldekortdetaljer.meldeperiode)
         assert(meldekortkontroll.meldegruppe.equals("DAGP"))
+        assert(meldekortkontroll.personId.equals(meldekortdetaljer.personId))
         assert(meldekortkontroll.sporsmal.annetFravaer == sporsmal.annetFravaer)
         assert(meldekortkontroll.sporsmal.arbeidet == sporsmal.arbeidet)
         assert(meldekortkontroll.sporsmal.arbeidssoker == sporsmal.arbeidssoker)


### PR DESCRIPTION
Har testet i q1 med den versjonen av meldekortkontroll-api som ligger i prod, ingen feilmeldinger.