### PR TITLE
liveness og readiness timeout 10

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -25,11 +25,11 @@ spec:
   {{/each}}
   liveness:
     path: /meldekortservice/internal/isAlive
-    initialDelay: 10
+    initialDelay: 15
     timeout: 10
   readiness:
     path: /meldekortservice/internal/isReady
-    initialDelay: 10
+    initialDelay: 15
     timeout: 10
   vault:
     enabled: true

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -26,9 +26,11 @@ spec:
   liveness:
     path: /meldekortservice/internal/isAlive
     initialDelay: 10
+    timeout: 10
   readiness:
     path: /meldekortservice/internal/isReady
     initialDelay: 10
+    timeout: 10
   vault:
     enabled: true
     paths:


### PR DESCRIPTION
Nye poder startes, gamle slettes, men nye poder restartes pga
Liveness probe failed: Get "http://192.168.62.104:8090/meldekortservice/internal/isAlive": context deadline exceeded (Client.Timeout exceeded while awaiting headers)

Dvs. vi får mellomrom en pause i tjenesten