### PR TITLE
TokenX

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -52,8 +52,6 @@ spec:
       cpu: 500m
       memory: 2Gi
   env:
-    - name: IDPORTEN_ACCEPTED_AUDIENCE
-      value: '{{ idportenAcceptedAudience }}'
     - name: TOKEN_X_ACCEPTED_AUDIENCE
       value: '{{ tokenxAcceptedAudience }}'
   tokenx:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -56,13 +56,5 @@ spec:
       value: '{{ idportenAcceptedAudience }}'
     - name: TOKEN_X_ACCEPTED_AUDIENCE
       value: '{{ tokenxAcceptedAudience }}'
-  idporten:
-    enabled: true
-    sidecar:
-      enabled: true
-      level: Level3
-      locale: nb
-      autoLogin: false
-      errorPath: ""
   tokenx:
     enabled: true

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -58,5 +58,11 @@ spec:
       value: '{{ tokenxAcceptedAudience }}'
   idporten:
     enabled: true
+    sidecar:
+      enabled: true
+      level: Level3
+      locale: nb
+      autoLogin: false
+      errorPath: ""
   tokenx:
     enabled: true

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -56,3 +56,9 @@ spec:
       value: '{{ tokenxAcceptedAudience }}'
   tokenx:
     enabled: true
+  accessPolicy:
+    inbound:
+      rules:
+        - application: meldekort-api{{ dashEnv }}
+          namespace: meldekort
+          cluster: {{ vaultServiceuserEnv }}-gcp

--- a/.nais/vars-p.yaml
+++ b/.nais/vars-p.yaml
@@ -4,5 +4,4 @@ vaultKvEnv: prod/fss
 vaultServiceuserEnv: prod
 ingresses:
   - "https://meldekortservice.prod-fss-pub.nais.io"
-idportenAcceptedAudience: https://nav.no
 tokenxAcceptedAudience: prod-gcp:meldekort:meldekort-api

--- a/.nais/vars-p.yaml
+++ b/.nais/vars-p.yaml
@@ -4,4 +4,4 @@ vaultKvEnv: prod/fss
 vaultServiceuserEnv: prod
 ingresses:
   - "https://meldekortservice.prod-fss-pub.nais.io"
-tokenxAcceptedAudience: prod-gcp:meldekort:meldekort-api
+tokenxAcceptedAudience: prod-gcp:meldekort:meldekortservice

--- a/.nais/vars-p.yaml
+++ b/.nais/vars-p.yaml
@@ -4,4 +4,4 @@ vaultKvEnv: prod/fss
 vaultServiceuserEnv: prod
 ingresses:
   - "https://meldekortservice.prod-fss-pub.nais.io"
-tokenxAcceptedAudience: prod-gcp:meldekort:meldekortservice
+tokenxAcceptedAudience: prod-fss:meldekort:meldekortservice

--- a/.nais/vars-q1.yaml
+++ b/.nais/vars-q1.yaml
@@ -4,4 +4,4 @@ vaultKvEnv: preprod/fss
 vaultServiceuserEnv: dev
 ingresses:
   - "https://meldekortservice-q1.dev-fss-pub.nais.io"
-tokenxAcceptedAudience: dev-gcp:meldekort:meldekort-api-q1
+tokenxAcceptedAudience: dev-gcp:meldekort:meldekortservice-q1

--- a/.nais/vars-q1.yaml
+++ b/.nais/vars-q1.yaml
@@ -4,4 +4,4 @@ vaultKvEnv: preprod/fss
 vaultServiceuserEnv: dev
 ingresses:
   - "https://meldekortservice-q1.dev-fss-pub.nais.io"
-tokenxAcceptedAudience: dev-gcp:meldekort:meldekortservice-q1
+tokenxAcceptedAudience: dev-fss:meldekort:meldekortservice-q1

--- a/.nais/vars-q1.yaml
+++ b/.nais/vars-q1.yaml
@@ -4,5 +4,4 @@ vaultKvEnv: preprod/fss
 vaultServiceuserEnv: dev
 ingresses:
   - "https://meldekortservice-q1.dev-fss-pub.nais.io"
-idportenAcceptedAudience: https://nav.no
 tokenxAcceptedAudience: dev-gcp:meldekort:meldekort-api-q1

--- a/.nais/vars-q2.yaml
+++ b/.nais/vars-q2.yaml
@@ -4,4 +4,4 @@ vaultKvEnv: preprod/fss
 vaultServiceuserEnv: dev
 ingresses:
   - "https://meldekortservice-q2.dev-fss-pub.nais.io"
-tokenxAcceptedAudience: dev-gcp:meldekort:meldekort-api-q2
+tokenxAcceptedAudience: dev-gcp:meldekort:meldekortservice-q2

--- a/.nais/vars-q2.yaml
+++ b/.nais/vars-q2.yaml
@@ -4,5 +4,4 @@ vaultKvEnv: preprod/fss
 vaultServiceuserEnv: dev
 ingresses:
   - "https://meldekortservice-q2.dev-fss-pub.nais.io"
-idportenAcceptedAudience: https://nav.no
 tokenxAcceptedAudience: dev-gcp:meldekort:meldekort-api-q2

--- a/.nais/vars-q2.yaml
+++ b/.nais/vars-q2.yaml
@@ -4,4 +4,4 @@ vaultKvEnv: preprod/fss
 vaultServiceuserEnv: dev
 ingresses:
   - "https://meldekortservice-q2.dev-fss-pub.nais.io"
-tokenxAcceptedAudience: dev-gcp:meldekort:meldekortservice-q2
+tokenxAcceptedAudience: dev-fss:meldekort:meldekortservice-q2

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Det er også mulig å kjøre `gradle clean build`, men da må man ha en riktig v
 1. Start lokal instans av Postgres ved å kjøre `docker-compose up -d`.
 2. Start appen ved å kjøre `./gradlew runServerTest`.
 Det er også mulig å kjøre Server.kt sin main-metode eller `./gradlew runServer`, men da må man sette miljøvariablene:
-IDPORTEN_WELL_KNOWN_URL
-IDPORTEN_ACCEPTED_AUDIENCE
 TOKEN_X_WELL_KNOWN_URL
 TOKEN_X_ACCEPTED_AUDIENCE
 For å kjøre mot f.eks Q1 kan man enten sette riktige miljøvariabler (manuelt eller ved hjelp av bat/bash script) eller midlertidig skrive disse inn i Environment.kt i stedet for defaultValue'er.  

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,8 +155,6 @@ tasks {
     }
 
     register("runServerTest", JavaExec::class) {
-        systemProperties["IDPORTEN_WELL_KNOWN_URL"] = "idporten.dev.nav.no"
-        systemProperties["IDPORTEN_ACCEPTED_AUDIENCE"] = "nav.no"
         systemProperties["TOKEN_X_WELL_KNOWN_URL"] = "tokenx.dev.nav.no"
         systemProperties["TOKEN_X_ACCEPTED_AUDIENCE"] = "nav.no"
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -11,11 +11,6 @@ ktor {
 no.nav.security.jwt {
     issuers = [
         {
-            issuer_name = "idporten"
-            discoveryurl = ${IDPORTEN_WELL_KNOWN_URL}
-            accepted_audience = ${IDPORTEN_ACCEPTED_AUDIENCE}
-        },
-        {
             issuer_name = "tokenx"
             discoveryurl = ${TOKEN_X_WELL_KNOWN_URL}
             accepted_audience = ${TOKEN_X_ACCEPTED_AUDIENCE}


### PR DESCRIPTION
Vi må fjerne direkte integrasjoner mot ID-porten. Dvs. vi må bytte ut tokenet fra ID-porten vi får i meldekort-api med TokenX før vi gjør kall til FSS
Se https://nav-it.slack.com/docs/T5LNAMWNA/F05BACREUKB?focus_section_id=temp:C:VNA04f07e82553b43409b7d03e7a